### PR TITLE
rollout new django version -- deploy with caution.

### DIFF
--- a/rdiodj/management/commands/master.py
+++ b/rdiodj/management/commands/master.py
@@ -15,6 +15,9 @@ WAIT_FOR_USERS = timedelta(minutes=5)
 
 
 class Command(BaseCommand):
+    def add_arguments(self, parser):
+        parser.add_argument('room_name', type=str)
+
     def handle(self, room_name, *args, **kwargs):
         self.firebase = firebase.FirebaseApplication(settings.FIREBASE_URL)
         auth = firebase.FirebaseAuthentication(settings.FIREBASE_TOKEN, 'mkapolk@gmail.com')

--- a/rdiodj/settings.py
+++ b/rdiodj/settings.py
@@ -119,7 +119,7 @@ ROOT_URLCONF = 'rdiodj.urls'
 WSGI_APPLICATION = 'rdiodj.wsgi.application'
 
 TEMPLATE_DIRS = (
-    '%s/template' % os.path.abspath(os.path.split(__file__)[0])
+    '%s/template' % os.path.abspath(os.path.split(__file__)[0]),
 )
 
 INSTALLED_APPS = (
@@ -138,11 +138,11 @@ INSTALLED_APPS = (
 )
 
 TEMPLATE_CONTEXT_PROCESSORS = (
-    'django.core.context_processors.debug',
-    'django.core.context_processors.i18n',
-    'django.core.context_processors.media',
-    'django.core.context_processors.static',
-    'django.core.context_processors.request',
+    'django.template.context_processors.debug',
+    'django.template.context_processors.i18n',
+    'django.template.context_processors.media',
+    'django.template.context_processors.static',
+    'django.template.context_processors.request',
     'django.contrib.auth.context_processors.auth',
     'django.contrib.messages.context_processors.messages',
     'social_auth.context_processors.social_auth_by_name_backends',

--- a/rdiodj/urls.py
+++ b/rdiodj/urls.py
@@ -1,26 +1,28 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 from django.contrib import admin
+from django.contrib.auth import logout
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
+from rdiodj import views
 
 
 admin.autodiscover()
 
 
-urlpatterns = patterns('',
-    url(r'^$', 'rdiodj.views.home', name='index'),
-    url(r'^p/((?P<room_name>[A-Za-z0-9\-_]+)/)?$', 'rdiodj.views.party', name='party'),
-    url(r'^parties/$', 'rdiodj.views.parties', name='parties'),
+urlpatterns = [
+    url(r'^$', views.home, name='index'),
+    url(r'^p/((?P<room_name>[A-Za-z0-9\-_]+)/)?$', views.party, name='party'),
+    url(r'^parties/$', views.parties, name='parties'),
 
-    url(r'^sign-out/$', 'django.contrib.auth.views.logout', {'next_page': '/'}, name='sign-out'),
+    url(r'^sign-out/$', logout, {'next_page': '/'}, name='sign-out'),
 
-    url(r'^player/helper/', 'rdiodj.views.player_helper', name='player-helper'),
+    url(r'^player/helper/', views.player_helper, name='player-helper'),
 
     url(r'^auth/', include('social_auth.urls')),
 
     url(r'^admin/doc/', include('django.contrib.admindocs.urls')),
     url(r'^admin/', include(admin.site.urls)),
-    url(r'^create-auth/', 'rdiodj.views.createauthtoken')
-)
+    url(r'^create-auth/', views.createauthtoken)
+]
 
 
 urlpatterns += staticfiles_urlpatterns()

--- a/rdiodj/views.py
+++ b/rdiodj/views.py
@@ -1,10 +1,7 @@
 from django.conf import settings
 from django.contrib.auth import logout
 from django.contrib.auth.decorators import login_required
-from django.core.urlresolvers import reverse
-from django.http import HttpResponse
-from django.shortcuts import redirect, render_to_response
-from django.template import RequestContext
+from django.shortcuts import redirect, render
 import json
 from django.http import HttpResponse
 
@@ -13,16 +10,15 @@ import psutil
 import os
 from firebase_token_generator import create_token
 
+
 def home(request):
-    c = RequestContext(request, {
+    context = {
         # Something good
         'body_class': 'home'
-    })
-    return render_to_response('index.html', c)
+    }
+    return render(request, 'index.html', context)
 
 def createauthtoken(request):
-    response = None
-
     rdio_user_key = request.GET.get('userKey')
     if rdio_user_key:
         custom_data = {'rdio_user_key': rdio_user_key}
@@ -32,7 +28,7 @@ def createauthtoken(request):
     else:
         response = {"error": "userKey is a required GET param"}
 
-    return HttpResponse(json.dumps(response), content_type = "application/json")
+    return HttpResponse(json.dumps(response), content_type="application/json")
 
 def make_room_daemon(room_name):
   child_processes = psutil.Process(os.getpid()).get_children()
@@ -50,30 +46,27 @@ def make_room_daemon(room_name):
 def party(request, room_name):
     if room_name is None:
         return redirect('/p/rdio')
-
-    c = RequestContext(request, {
+    context = {
         'firebase_url': "%s/%s" % (settings.FIREBASE_URL, room_name),
         'room_name': room_name,
         'body_class': 'party'
-    })
+    }
     make_room_daemon(room_name)
-    return render_to_response('party.html', c)
+    return render(request, 'party.html', context)
 
 
 def parties(request):
-    c = RequestContext(request, {
+    context = {
         'firebase_url': "%s/" % (settings.FIREBASE_URL,),
         'body_class': 'parties'
-    })
-    return render_to_response('partylist.html', c)
+    }
+    return render(request, 'partylist.html', context)
 
 
 def sign_out(request):
-    response = logout(request, next_page=reverse('index'))
-    return HttpResponse(response)
+    logout(request)
+    return redirect('/')
 
 
 def player_helper(request):
-    return render_to_response('player-helper.html',
-                              {},
-                              context_instance=RequestContext(request))
+    return render(request, 'player-helper.html')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-Django==1.5
+Django==1.8.1
 boto==2.8.0
 dj-database-url==0.2.1
-django-social-auth==0.7.22
+django-social-auth==0.7.28
 django-storages==1.1.6
 firebase-token-generator==1.2
 httplib2==0.8
@@ -15,3 +15,4 @@ python-firebase==1.2
 Rdio==0.3.0
 psutil==2.2.0
 python-dateutil==2.4.1
+simplejson==3.6.5


### PR DESCRIPTION
Welcome to the present!

I was running it locally using `foreman run python -Wall manage.py runserver` to track down warnings.

Apparently, social_auth is not ready for django 2.0 yet so there is a bunch of deprecation warnings still in place but guess what? Django 2.0 is the future and we are using django 1.8. It looks like our code is up to date with the changes I made. And it works locally.

Note: Maybe something as to change in prod too with the way we run it. 

To run locally you will need to run `pip install -r requirements.txt` to get the new version.